### PR TITLE
Apply blur filter to the dialog's backdrop instead

### DIFF
--- a/src/components/common/BlurBehindDialog.tsx
+++ b/src/components/common/BlurBehindDialog.tsx
@@ -1,0 +1,21 @@
+import { Dialog, DialogProps, makeStyles } from '@material-ui/core'
+import React from 'react'
+
+const useStyles = makeStyles({
+  backdrop: {
+    backdropFilter: 'blur(8px)',
+  },
+})
+
+export function BlurBehindDialog(props: DialogProps) {
+  const classes = useStyles()
+  return (
+    <Dialog
+      {...props}
+      BackdropProps={{
+        ...props.BackdropProps,
+        className: `${classes.backdrop} ${props.BackdropProps?.className}`,
+      }}
+    />
+  )
+}

--- a/src/components/pages/baan/component/cardDialog.tsx
+++ b/src/components/pages/baan/component/cardDialog.tsx
@@ -1,7 +1,6 @@
 import {
   Avatar,
   Box,
-  Dialog,
   Link,
   Theme,
   Typography,
@@ -11,6 +10,7 @@ import MuiDialogActions from '@material-ui/core/DialogActions'
 import MuiDialogContent from '@material-ui/core/DialogContent'
 import FacebookIcon from '@material-ui/icons/Facebook'
 import InstagramIcon from '@material-ui/icons/Instagram'
+import { BlurBehindDialog } from 'components/common/BlurBehindDialog'
 import i18n from 'i18next'
 import { getBaan, getLogo } from 'local/BaanInfo'
 import React from 'react'
@@ -55,10 +55,9 @@ const CardDialog = function CardDialog(props: ICardDialog) {
   const value = getBaan(ID)
 
   return (
-    <Dialog
+    <BlurBehindDialog
       onClose={handleClose}
       open={open}
-      className={classes.dialog_popup}
       PaperProps={{
         style: {
           backgroundColor: '#383838',
@@ -118,7 +117,7 @@ const CardDialog = function CardDialog(props: ICardDialog) {
       <DialogActions>
         <SubmitButton color={color} disabled={disabled} ID={value.ID} />
       </DialogActions>
-    </Dialog>
+    </BlurBehindDialog>
   )
 }
 

--- a/src/components/pages/baan/component/dialogComponent.tsx
+++ b/src/components/pages/baan/component/dialogComponent.tsx
@@ -34,7 +34,6 @@ const styles = (theme: Theme) =>
     fbandigicon_text: {},
     avatar_picture: {},
     avatar_picture_card: {},
-    dialog_popup: {},
     focusHighlight: {},
     actionArea: {},
   })

--- a/src/components/pages/baan/style/cardDialogStyle.tsx
+++ b/src/components/pages/baan/style/cardDialogStyle.tsx
@@ -86,12 +86,6 @@ const useStyles = makeStyles((theme) => ({
       width: '75px',
     },
   },
-  dialog_popup: {
-    backdropFilter: 'blur(8px)',
-    position: 'absolute',
-    right: '50px',
-    top: '105px',
-  },
 }))
 
 export default useStyles

--- a/src/components/pages/form/component/Image.tsx
+++ b/src/components/pages/form/component/Image.tsx
@@ -1,7 +1,6 @@
 import {
   Box,
   Button,
-  Dialog,
   DialogContentText,
   DialogTitle,
   IconButton,
@@ -13,6 +12,7 @@ import { TransitionProps } from '@material-ui/core/transitions/transition'
 import CloseIcon from '@material-ui/icons/Close'
 import ZoomInIcon from '@material-ui/icons/ZoomIn'
 import ZoomOutIcon from '@material-ui/icons/ZoomOut'
+import { BlurBehindDialog } from 'components/common/BlurBehindDialog'
 import React, { useCallback, useEffect, useState } from 'react'
 import Cropper from 'react-easy-crop'
 import { useTranslation } from 'react-i18next'
@@ -137,7 +137,7 @@ const Image = React.memo(function Image(props: React.PropsWithRef<any>) {
 
   return (
     <Box display="flex" alignItems="center" flexDirection="column" m={0}>
-      <Dialog
+      <BlurBehindDialog
         open={cropState}
         maxWidth="sm"
         fullWidth={true}
@@ -148,7 +148,6 @@ const Image = React.memo(function Image(props: React.PropsWithRef<any>) {
         TransitionComponent={Transition}
         keepMounted
         onClose={closeDialog}
-        style={{ backdropFilter: 'blur(8px)' }}
       >
         <DialogTitle>
           <IconButton
@@ -244,7 +243,7 @@ const Image = React.memo(function Image(props: React.PropsWithRef<any>) {
             {t('confirmCrop')}
           </Button>
         ) : null}
-      </Dialog>
+      </BlurBehindDialog>
 
       {finalImg ? (
         <Box>

--- a/src/components/pages/form/component/formDialogComponent.tsx
+++ b/src/components/pages/form/component/formDialogComponent.tsx
@@ -1,11 +1,11 @@
 import {
   Button,
-  Dialog,
   DialogActions,
   DialogContent,
   DialogTitle,
   Typography,
 } from '@material-ui/core'
+import { BlurBehindDialog } from 'components/common/BlurBehindDialog'
 import React from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -23,13 +23,12 @@ const FormDialog = React.memo(function FormDialog(props: IFormDialog) {
   const { t } = useTranslation('form')
   const { confirmOpen, closeDialog, submit, text } = props
   return (
-    <Dialog
+    <BlurBehindDialog
       open={confirmOpen}
       onClose={closeDialog}
       PaperProps={{
         classes: { root: style.dialog },
       }}
-      style={{ backdropFilter: 'blur(8px)' }}
     >
       <DialogTitle classes={{ root: style.dialogTitle }}>
         <Typography className={style.dialogTitle}>
@@ -55,7 +54,7 @@ const FormDialog = React.memo(function FormDialog(props: IFormDialog) {
           {t('confirm')}
         </Button>
       </DialogActions>
-    </Dialog>
+    </BlurBehindDialog>
   )
 })
 


### PR DESCRIPTION
Here's a comparison of before & after the fix. Look closely at the texts behind the blur background when the dialog is transitioning. 

https://user-images.githubusercontent.com/8080853/103452257-e3f83c80-4cff-11eb-9abc-1a2372e9f620.mov

